### PR TITLE
Update to ESO v1.0.0 apis and network policies.

### DIFF
--- a/console/quick-start/external-secrets-operator/eso-example-quickstart.yaml
+++ b/console/quick-start/external-secrets-operator/eso-example-quickstart.yaml
@@ -35,7 +35,7 @@ spec:
     - title: Navigate to installed external secrets operator
       description: |-
         ### To navigate to the installed operator:
-        1. From the **Administrators** perspective, go to the **Installed Operators** from the [Operators]{{highlight qs-nav-operators}} section of the navigation.
+        1. From the **Administrators** perspective, go to the **Installed Operators** from the [Ecosystem]{{highlight qs-nav-ecosystem}} section of the navigation.
         2. In the **Search by name** field, type `External Secrets Operator`.
         3. Look for **External Secrets Operator for Red Hat OpenShift**. If you had completed the prerequisite Quick Start, the tile should appear.
         4. Click on the installed operator

--- a/console/quick-start/external-secrets-operator/eso-external-secret-sample.yaml
+++ b/console/quick-start/external-secrets-operator/eso-external-secret-sample.yaml
@@ -4,13 +4,13 @@ metadata:
   name: eso-external-secret-sample
 spec:
   targetResource:
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: ExternalSecret
   title: Example ExternalSecret
   description: |
     An example minimal ExternalSecret manifest
   yaml: |
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: ExternalSecret
     metadata:
       name: EXTERNAL_SECRET_NAME

--- a/console/quick-start/external-secrets-operator/eso-install-quickstart.yaml
+++ b/console/quick-start/external-secrets-operator/eso-install-quickstart.yaml
@@ -55,9 +55,21 @@ spec:
         4. Find the `ExternalSecretsConfigs` Custom Resource in the **Provided APIs** list or in the top side-scrolling menu bar.
           - From the list of **Provided APIs** click the **Create instance** link
           - From the **top side-scrolling menu bar** click **ExternalSecretsConfigs** and then click **Create ExternalSecretsConfig**
-        5. For this QuickStart, you can use the default configurations for the `ExternalSecretsConfig` Deployment.
-          - NOTE: This CR enables you to add additional configurations including ingress and egress network policies.
-        6. Click **Create**
+        5. For this QuickStart, you can use the default configurations for the `ExternalSecretsConfig` Deployment, including an `allow-all` egress policy.
+          - NOTE: an `allow-all` egress policy is not recommended in production environments.
+        6. Copy the below manifest into the console editor for the **ExternalSecretsConfig** deployment.
+
+        ```
+        spec:
+          controllerConfig:
+            networkPolicies:
+              - name: allow-external-secrets-egress
+                componentName: ExternalSecretsCoreController
+                egress:
+                - {}
+        ```
+
+        7. Click **Create**
       review:
         instructions: |-
           #### Verify the operand was successfully installed:

--- a/console/quick-start/external-secrets-operator/eso-install-quickstart.yaml
+++ b/console/quick-start/external-secrets-operator/eso-install-quickstart.yaml
@@ -26,7 +26,7 @@ spec:
     - title: Install the external secrets operator for Red Hat OpenShift
       description: |-
         ### To install the operator:
-        1. From the **Administrators** perspective, go to the **OperatorHub** from the [Operators]{{highlight qs-nav-operators}} section of the navigation.
+        1. From the **Administrators** perspective, go to the **Software Catalog** from the [Ecosystem]{{highlight qs-nav-ecosystem}} section of the navigation.
         2. In the **Filter by keyword** field, type `External Secrets Operator`.
         3. Look for **External Secrets Operator for Red Hat OpenShift**. If the tile has an **Installed** label on it, the Operator is already installed, and you can close this Quick Start.
         4. Click the tile to open the side panel.
@@ -45,19 +45,19 @@ spec:
         ### The ExternalSecrets Operand
         Installing the external secrets operator provides you with the necessary APIs to deploy the ExternalSecrets operand.
 
-        When an ExternalSecrets CR is deployed, a new Deployment is created that manages the external-secrets singleton and
+        When an ExternalSecretsConfig CR is deployed, a new Deployment is created that manages the external-secrets singleton and
         keeps it in the desired state.
 
-        ### To deploy the ExternalSecrets Custom Resource:
-        1. From the **Administrators** perspective, go to the **Installed Operators** from the [Operators]{{highlight qs-nav-operators}} section of the navigation.
+        ### To deploy the ExternalSecretsConfig Custom Resource:
+        1. From the **Administrators** perspective, go to the **Installed Operators** from the [Ecosystem]{{highlight qs-nav-ecosystem}} section of the navigation.
         2. In the **Search by name** field, type `External Secrets Operator`.
         3. Click on the **external secrets operator for Red Hat OpenShift**
-        4. Find the `ExternalSecrets` Custom Resource in the **Provided APIs** list or in the top side-scrolling menu bar.
-          - NOTE: MAKE SURE YOU ARE SELECTING **ExternalSecrets** AND **NOT** **ExternalSecret**
+        4. Find the `ExternalSecretsConfigs` Custom Resource in the **Provided APIs** list or in the top side-scrolling menu bar.
           - From the list of **Provided APIs** click the **Create instance** link
-          - From the **top side-scrolling menu bar** click **SecretStore** and then click **Create SecretStore**
-        5. For this QuickStart, you can use the default configurations for the `ExternalSecrets` Deployment.
-        6. Enter a name for the deployment, and then click **Create**
+          - From the **top side-scrolling menu bar** click **ExternalSecretsConfigs** and then click **Create ExternalSecretsConfig**
+        5. For this QuickStart, you can use the default configurations for the `ExternalSecretsConfig` Deployment.
+          - NOTE: This CR enables you to add additional configurations including ingress and egress network policies.
+        6. Click **Create**
       review:
         instructions: |-
           #### Verify the operand was successfully installed:

--- a/console/quick-start/external-secrets-operator/eso-vault-provider-sample.yaml
+++ b/console/quick-start/external-secrets-operator/eso-vault-provider-sample.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eso-vault-secret-store-provider-sample
 spec:
   targetResource:
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: SecretStore
   title: Example SecretStore - HashiCorp Vault Kubernetes Authentication
   description: |
@@ -12,7 +12,7 @@ spec:
     Documentation can be found in the HashiCorp Documentation
     here: https://developer.hashicorp.com/vault/docs/auth/kubernetes
   yaml: |
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: SecretStore
     metadata:
       name: SECRET_STORE_NAME

--- a/demos/external-secrets-operator/busybox/src/config/eso_resources.yaml
+++ b/demos/external-secrets-operator/busybox/src/config/eso_resources.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend
@@ -24,7 +24,7 @@ spec:
             name: "eso-demo-sa"
             namespace: "eso-demo-ns"
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: vault-external-secret

--- a/demos/external-secrets-operator/operator/config/eso.yaml
+++ b/demos/external-secrets-operator/operator/config/eso.yaml
@@ -1,7 +1,13 @@
 apiVersion: operator.openshift.io/v1alpha1
-kind: ExternalSecrets
+kind: ExternalSecretsConfig
 metadata:
   labels:
     app.kubernetes.io/name: external-secrets-operator
   name: cluster
-spec: {}
+spec:
+  controllerConfig:
+    networkPolicies:
+      - name: allow-external-secrets-egress
+        componentName: ExternalSecretsCoreController
+        egress:
+        - {}

--- a/demos/external-secrets-operator/operator/config/operator.yaml
+++ b/demos/external-secrets-operator/operator/config/operator.yaml
@@ -12,8 +12,9 @@ metadata:
   name: openshift-external-secrets-operator
   namespace: external-secrets-operator
 spec:
-  channel: tech-preview-v0.1
+  channel: stable-v1
   name: openshift-external-secrets-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   installPlanApproval: Automatic
+  startingCSV: external-secrets-operator.v1.0.0

--- a/demos/external-secrets-operator/policies/src/config/eso_resources.yaml
+++ b/demos/external-secrets-operator/policies/src/config/eso_resources.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend
@@ -24,7 +24,7 @@ spec:
             name: "eso-demo-sa"
             namespace: "eso-demo-ns"
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: vault-external-secret


### PR DESCRIPTION
* Deploy operand via ExternalSecretConfig instead of ExternalSecrets
* Add network policy (allow-all) to ExternalSecretConfig to facilitate demos. Not recommended for prod envs
* Bump to /v1 apis
* Update `qs-nav-operators` quickstart highlights to `qs-nav-ecosystem` after changes in console for 4.20