### PR TITLE
[FIX] Fixes misconception regarding `list` verb in Secretless demo

### DIFF
--- a/demos/external-secrets-operator/secretless/README.md
+++ b/demos/external-secrets-operator/secretless/README.md
@@ -29,6 +29,13 @@ ESO CRD and still have the useful information needed to debug a workload
 while not being permitted to actually inspect the underlying Kubernetes
 Secret.
 
+**Important Note:** Even the Kubernetes `list` verb returns the full Secret
+object data, including base64-encoded values. This means `oc get secrets -o yaml`
+exposes all secret content even without the `get` verb. Therefore, this demo
+removes **all** Secret access from user roles rather than attempting to grant
+limited access. Kubernetes Events are granted instead, providing diagnostic
+information (e.g., mount failures, sync errors) without exposing secret values.
+
 ## Prerequisites
 
 Must have the following installed
@@ -65,8 +72,8 @@ Must have admin credentials for an OpenShift cluster and be logged in via:
 # Deploys the necessary External Secrets Operator CRDs to test access with
 ./04_deploy_eso_crds.sh
 
-# Validates that the created and configured users CANNOT access the Secrets managed
-# by ESO and that only the `demo_admin` user can access the ESO CRDs
+# Validates that neither user has ANY access to Kubernetes Secrets, and that
+# only the `demo_admin` user can access the ESO CRDs for debugging
 ./05_validate_admin_permissions.sh
 ./06_validate_user_permissions.sh
 
@@ -83,9 +90,7 @@ via the OpenShift Console. To do this:
 1. Log into the OpenShift Console with the appropriate user credentials
 2. Select the `Workloads` tab on the left-hand tool bar
 3. Select the `Secrets` option in the `Workloads` dropdown menu
-  - Verfiy that the user can see a list of secrets
-  ![Success List Secret](images/success_list_secret.png)
-  - Verify that when you click on a specific secret, you get a permissions error
+  - Verify that the user CANNOT see any secrets (should see a permissions error)
   ![Forbidden Describe Secret](images/forbidden_describe_secret.png)
 4. As the `demo_admin` user, select the `Ecosystem` tab and select `Installed Operators`. You might need to select a specific project first.
   - Verify that you can see the installed External Secrets Operator

--- a/demos/external-secrets-operator/secretless/src/04_deploy_eso_crds.sh
+++ b/demos/external-secrets-operator/secretless/src/04_deploy_eso_crds.sh
@@ -27,3 +27,13 @@ sed \
   -e "s|VAULT_SVC_CLUSTER_IP|$IP_ADDRESS|g" \
   $SCRIPT_DIR/config/eso_resources.yaml > $SCRIPT_DIR/config/tmp_eso_resources.yaml
 oc apply -f $SCRIPT_DIR/config/tmp_eso_resources.yaml
+
+# Deploy demo pods to showcase events-based debugging
+# - demo-app-success: mounts the ESO-managed secret correctly
+# - demo-app-failure: references a non-existent secret (simulates a typo)
+echo ""
+echo "Deploying demo pods for events demonstration..."
+oc apply -f $SCRIPT_DIR/config/demo_pods.yaml
+echo "Waiting for demo-app-success pod to be ready..."
+oc wait --for=condition=Ready pod/demo-app-success -n demo-namespace-user --timeout=60s
+echo "demo-app-failure pod will remain in ContainerCreating (expected - secret does not exist)"

--- a/demos/external-secrets-operator/secretless/src/05_validate_admin_permissions.sh
+++ b/demos/external-secrets-operator/secretless/src/05_validate_admin_permissions.sh
@@ -16,10 +16,12 @@ USER_NS="demo-namespace-user"
 YES="yes"
 NO="no"
 
-# Admin should be able to list secrets and get externalsecrets but NOT get secrets
+# Admin should NOT have any access to secrets, but CAN get externalsecrets and events
 # This should be true in both demo namespaces
-can_i "list" "secrets" $ADMIN_NS $ADMIN_USER $YES
-can_i "list" "secrets" $USER_NS $ADMIN_USER $YES
+can_i "list" "secrets" $ADMIN_NS $ADMIN_USER $NO
+can_i "list" "secrets" $USER_NS $ADMIN_USER $NO
+can_i "list" "events" $ADMIN_NS $ADMIN_USER $YES
+can_i "list" "events" $USER_NS $ADMIN_USER $YES
 can_i "list" "externalsecrets" $ADMIN_NS $ADMIN_USER $YES
 can_i "list" "externalsecrets" $USER_NS $ADMIN_USER $YES
 can_i "get" "externalsecrets" $ADMIN_NS $ADMIN_USER $YES
@@ -36,13 +38,17 @@ echo ""
 echo "Validating that admin user can perform above tested functions"
 echo "YOU MUST VALIDATE THESE VISUALLY"
 echo ""
-echo "$ADMIN_USER can list secrets, should see list of secrets"
+echo "$ADMIN_USER CANNOT list secrets, should see forbidden error"
 oc get secrets -n $ADMIN_NS --as $ADMIN_USER
 oc get secrets -n $USER_NS --as $ADMIN_USER
 echo ""
-echo "$ADMIN_USER CANNOT describe secrets, should see forbidden error" 
+echo "$ADMIN_USER CANNOT describe secrets, should see forbidden error"
 oc get secret vault-secret-example -n $USER_NS --as $ADMIN_USER
 oc get secret vault-special-secret-example -n $USER_NS --as $ADMIN_USER
+echo ""
+echo "$ADMIN_USER can list events, should see event information"
+oc get events -n $ADMIN_NS --as $ADMIN_USER
+oc get events -n $USER_NS --as $ADMIN_USER
 echo ""
 echo "$ADMIN_USER can list externalsecrets, should see list of externalsecrets"
 oc get externalsecrets -n $ADMIN_NS --as $ADMIN_USER

--- a/demos/external-secrets-operator/secretless/src/05_validate_admin_permissions.sh
+++ b/demos/external-secrets-operator/secretless/src/05_validate_admin_permissions.sh
@@ -50,6 +50,15 @@ echo "$ADMIN_USER can list events, should see event information"
 oc get events -n $ADMIN_NS --as $ADMIN_USER
 oc get events -n $USER_NS --as $ADMIN_USER
 echo ""
+echo "=== EVENTS DEBUGGING DEMO ==="
+echo "Events allow admins to diagnose pod issues WITHOUT accessing secrets."
+echo ""
+echo "demo-app-success pod events (should show successful scheduling and mount):"
+oc get events -n $USER_NS --as $ADMIN_USER --field-selector involvedObject.name=demo-app-success
+echo ""
+echo "demo-app-failure pod events (should show mount failure for non-existent secret):"
+oc get events -n $USER_NS --as $ADMIN_USER --field-selector involvedObject.name=demo-app-failure
+echo ""
 echo "$ADMIN_USER can list externalsecrets, should see list of externalsecrets"
 oc get externalsecrets -n $ADMIN_NS --as $ADMIN_USER
 oc get externalsecrets -n $USER_NS --as $ADMIN_USER

--- a/demos/external-secrets-operator/secretless/src/06_validate_user_permissions.sh
+++ b/demos/external-secrets-operator/secretless/src/06_validate_user_permissions.sh
@@ -16,11 +16,10 @@ USER_NS="demo-namespace-user"
 YES="yes"
 NO="no"
 
-# User should only be able to list secrets. NO other permissions
-# User should NOT be able to list secrets in admin namespace
-can_i "list" "secrets" $USER_NS $USER_USER $YES
-
+# User should NOT have any access to secrets. Can list events for diagnostics.
+can_i "list" "secrets" $USER_NS $USER_USER $NO
 can_i "list" "secrets" $ADMIN_NS $USER_USER $NO
+can_i "list" "events" $USER_NS $USER_USER $YES
 can_i "get" "secrets" $ADMIN_NS $USER_USER $NO
 can_i "get" "secrets" $USER_NS $USER_USER $NO
 can_i "list" "externalsecrets" $ADMIN_NS $USER_USER $NO
@@ -36,10 +35,12 @@ echo ""
 echo "Validating that admin user can perform above tested functions"
 echo "YOU MUST VALIDATE THESE VISUALLY"
 echo ""
-echo "$USER_USER can list secrets, should see list of secrets"
+echo "$USER_USER CANNOT list secrets, should see forbidden error"
 oc get secrets -n $USER_NS --as $USER_USER
-echo "$USER_USER CANNOT list secrets outside of their NS, should see forbidden error"
 oc get secrets -n $ADMIN_NS --as $USER_USER
+echo ""
+echo "$USER_USER can list events, should see event information"
+oc get events -n $USER_NS --as $USER_USER
 echo ""
 echo "$USER_USER CANNOT describe secrets, should see forbidden error"
 oc get secret vault-secret-example -n $USER_NS --as $USER_USER

--- a/demos/external-secrets-operator/secretless/src/06_validate_user_permissions.sh
+++ b/demos/external-secrets-operator/secretless/src/06_validate_user_permissions.sh
@@ -42,6 +42,15 @@ echo ""
 echo "$USER_USER can list events, should see event information"
 oc get events -n $USER_NS --as $USER_USER
 echo ""
+echo "=== EVENTS DEBUGGING DEMO ==="
+echo "Events allow users to diagnose pod issues WITHOUT accessing secrets."
+echo ""
+echo "demo-app-success pod events (should show successful scheduling and mount):"
+oc get events -n $USER_NS --as $USER_USER --field-selector involvedObject.name=demo-app-success
+echo ""
+echo "demo-app-failure pod events (should show mount failure for non-existent secret):"
+oc get events -n $USER_NS --as $USER_USER --field-selector involvedObject.name=demo-app-failure
+echo ""
 echo "$USER_USER CANNOT describe secrets, should see forbidden error"
 oc get secret vault-secret-example -n $USER_NS --as $USER_USER
 oc get secret vault-special-secret-example -n $ADMIN_NS --as $USER_USER

--- a/demos/external-secrets-operator/secretless/src/config/demo_pods.yaml
+++ b/demos/external-secrets-operator/secretless/src/config/demo_pods.yaml
@@ -1,0 +1,57 @@
+# Pod that correctly mounts the ESO-managed secret
+# This pod should start successfully and events will show normal scheduling/mount activity
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-app-success
+  namespace: demo-namespace-user
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: app
+    image: busybox:stable
+    command: ["sleep", "3600"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+    volumeMounts:
+    - name: secret-volume
+      mountPath: "/etc/secret"
+      readOnly: true
+  volumes:
+  - name: secret-volume
+    secret:
+      secretName: vault-secret-example # This secret exists (created by ESO)
+---
+# Pod that references a NON-EXISTENT secret (simulates a typo)
+# This pod will be stuck in ContainerCreating and events will show the mount failure
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-app-failure
+  namespace: demo-namespace-user
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: app
+    image: busybox:stable
+    command: ["sleep", "3600"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+    volumeMounts:
+    - name: secret-volume
+      mountPath: "/etc/secret"
+      readOnly: true
+  volumes:
+  - name: secret-volume
+    secret:
+      secretName: vault-secret-typo # This secret does NOT exist - simulates a typo

--- a/demos/external-secrets-operator/secretless/src/config/rolebinding.yaml
+++ b/demos/external-secrets-operator/secretless/src/config/rolebinding.yaml
@@ -13,10 +13,10 @@ rules:
 - apiGroups: ["", "apps", "autoscaling", "batch", "extensions", "networking.k8s.io", "route.openshift.io", "image.openshift.io"]
   resources: ["pods", "deployments", "services", "routes", "configmaps", "persistentvolumeclaims", "builds", "imagestreams", "namespaces"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-# 3. Restricted Secret Permissions
+# 3. Event visibility (for diagnosing mount failures, scheduling issues, etc.)
 - apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["list"] # ONLY list permitted
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -42,14 +42,14 @@ rules:
 - apiGroups: ["apps", "autoscaling", "batch", "extensions", "networking.k8s.io", "route.openshift.io", "image.openshift.io"]
   resources: ["*"]
   verbs: ["*"]
-# 2. Admin powers for Core Group ("") EXCEPT Secrets
+# 2. Admin powers for Core Group ("") - NO Secret access
 - apiGroups: [""]
   resources: ["pods", "services", "configmaps", "persistentvolumeclaims", "nodes", "namespaces", "endpoints", "resourcequotas"]
   verbs: ["*"]
-# 3. Specifically restricted Secrets permissions
+# 3. Event visibility (for diagnosing mount failures, sync issues, etc.)
 - apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["list"]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
 # 4. External Secrets Operator permissions
 - apiGroups: ["external-secrets.io"]
   resources: ["externalsecrets", "secretstores", "pushsecrets", "generators"]


### PR DESCRIPTION
The Kubernetes `list` verb actually _will_ permit a user to see all secret content if used with `-o yaml`. Therefore, for this demo to achieve its goal, the user RBAC should have NONE of the `get` or `list` verbs.
* Remove `list` verb from both users
* Update README and add necessary disclaimer
* Add ability to view `events`
* Show in demo how `events` verb enables better debug
